### PR TITLE
no duplicate contacts created on user reg

### DIFF
--- a/civicrm.module
+++ b/civicrm.module
@@ -571,7 +571,7 @@ function civicrm_form_user_register_form_alter(&$form, &$form_state, $form_id) {
 
   $form_state['no_cache'] = TRUE;
 
-  $html = CRM_Core_BAO_UFGroup::getEditHTML(NULL, '', 1, TRUE, FALSE, NULL, FALSE, civicrm_get_ctype('Individual'));
+  $html = CRM_Core_BAO_UFGroup::getEditHTML(NULL, '', 1, TRUE, FALSE, NULL, TRUE, civicrm_get_ctype('Individual'));
 
   if ($html) {
     $html = civicrm_add_jquery($html);
@@ -581,6 +581,40 @@ function civicrm_form_user_register_form_alter(&$form, &$form_state, $form_id) {
       '#weight' => 1,
     );
   }
+}
+
+/**
+ * Handler to validate CiviCRM fields on user registration form.
+ */
+function civicrm_user_form_validate($form, &$form_state) {
+  // lets suppress key generation for all validation also
+  civicrm_key_disable();
+
+  static $validated = FALSE;
+
+  if ($validated) {
+    return;
+  }
+
+  $validated = TRUE;
+
+  // check for either user/register or admin/people/create
+  $register =
+    ((arg(0) == 'user' && arg(1) == 'register') ||
+    (arg(0) == 'admin' && arg(1) == 'people' && arg(2) == 'create')
+  ) ? TRUE : FALSE;
+  $userID = NULL;
+  if (!empty($form['#user'])) {
+    $userID = CRM_Core_BAO_UFMatch::getContactId($form['#user']->uid);
+  }
+  $errors = CRM_Core_BAO_UFGroup::isValid($userID, NULL, $register);
+  if ($errors && is_array($errors)) {
+    foreach ($errors as $name => $error) {
+      form_set_error($name, $error);
+    }
+    return FALSE;
+  }
+  return TRUE;
 }
 
 /**
@@ -711,40 +745,6 @@ function _civicrm_get_user_profile_id($name) {
     ));
   }
   return $profileID;
-}
-
-/**
- * User Form Validate
- */
-function civicrm_user_form_validate($form, &$form_state) {
-  // lets suppress key generation for all validation also
-  civicrm_key_disable();
-
-  static $validated = FALSE;
-
-  if ($validated) {
-    return;
-  }
-
-  $validated = TRUE;
-
-  // check for either user/register or admin/people/create
-  $register =
-    ((arg(0) == 'user' && arg(1) == 'register') ||
-    (arg(0) == 'admin' && arg(1) == 'people' && arg(2) == 'create')
-  ) ? TRUE : FALSE;
-  $userID = NULL;
-  if (!empty($form['#user'])) {
-    $userID = CRM_Core_BAO_UFMatch::getContactId($form['#user']->uid);
-  }
-  $errors = CRM_Core_BAO_UFGroup::isValid($userID, 'civicrm-profile-register', $register);
-  if ($errors && is_array($errors)) {
-    foreach ($errors as $name => $error) {
-      form_set_error($name, $error);
-    }
-    return FALSE;
-  }
-  return TRUE;
 }
 
 /**

--- a/civicrm.module
+++ b/civicrm.module
@@ -571,7 +571,7 @@ function civicrm_form_user_register_form_alter(&$form, &$form_state, $form_id) {
 
   $form_state['no_cache'] = TRUE;
 
-  $html = CRM_Core_BAO_UFGroup::getEditHTML(NULL, '', NULL, TRUE, TRUE, NULL, TRUE, civicrm_get_ctype('Individual'));
+  $html = CRM_Core_BAO_UFGroup::getEditHTML(NULL, '', NULL, TRUE, TRUE, NULL, FALSE, civicrm_get_ctype('Individual'));
 
   if ($html) {
     $html = civicrm_add_jquery($html);

--- a/civicrm.module
+++ b/civicrm.module
@@ -571,7 +571,7 @@ function civicrm_form_user_register_form_alter(&$form, &$form_state, $form_id) {
 
   $form_state['no_cache'] = TRUE;
 
-  $html = CRM_Core_BAO_UFGroup::getEditHTML(NULL, '', 1, TRUE, FALSE, NULL, TRUE, civicrm_get_ctype('Individual'));
+  $html = CRM_Core_BAO_UFGroup::getEditHTML(NULL, '', NULL, TRUE, TRUE, NULL, TRUE, civicrm_get_ctype('Individual'));
 
   if ($html) {
     $html = civicrm_add_jquery($html);

--- a/civicrm.module
+++ b/civicrm.module
@@ -531,6 +531,9 @@ function civicrm_on_user_page() {
   return isset($_POST['_qf_default']);
 }
 
+/**
+ * Determine if profile is part of User Account group.
+ */
 function _civicrm_profiles_access($profile_id) {
   if (!civicrm_initialize()) {
     return FALSE;
@@ -543,6 +546,9 @@ function _civicrm_profiles_access($profile_id) {
   }
 }
 
+/**
+ * Callback for hook_menu for the profile title.
+ */
 function civicrm_profile_title_callback($profile_id, $fallback) {
   if (!civicrm_initialize() || empty($profile_id)) {
     return $fallback;
@@ -552,59 +558,29 @@ function civicrm_profile_title_callback($profile_id, $fallback) {
 }
 
 /**
- * Function needing explanation.
+ * Implements hook_form_FORM_ID_alter().
  *
- * @param $account
- * @param $reset
- * @param bool $doNotProcess
- *
- * @return array
+ * Attach any relevant profile form fields to user registration form.
  */
-function civicrm_register_data($account, $reset, $doNotProcess = FALSE) {
+function civicrm_form_user_register_form_alter(&$form, &$form_state, $form_id) {
   // lets suppress key generation for all registration forms
   civicrm_key_disable();
 
-  $ctype = civicrm_get_ctype('Individual');
-  if ($account->uid) {
-    // Happens on $type == 'insert'
-    // $reset == false always
-    // $doNotProcess == false always
-    CRM_Core_BAO_UFMatch::synchronize($account, TRUE, 'Backdrop', $ctype);
-    $userID = CRM_Core_BAO_UFMatch::getContactId($account->uid);
+  $form['#attributes']['enctype'] = 'multipart/form-data';
+  $form['#validate'][] = 'civicrm_user_form_validate';
 
-    // CRM-7858
-    if (isset($account->mail)) {
-      CRM_Core_BAO_UFMatch::updateContactEmail($userID,
-        trim($account->mail)
-      );
-    }
+  $form_state['no_cache'] = TRUE;
 
-    $html = CRM_Core_BAO_UFGroup::getEditHTML($userID, NULL, 2, TRUE, $reset,NULL, $doNotProcess, $ctype);
-  }
-  else {
-    // Happens on $type == 'register'
-    $html = CRM_Core_BAO_UFGroup::getEditHTML(NULL, NULL, 1, TRUE, $reset, NULL, $doNotProcess, $ctype);
-  }
-
-  $output = array();
+  $html = CRM_Core_BAO_UFGroup::getEditHTML(NULL, '', 1, TRUE, FALSE, NULL, FALSE, civicrm_get_ctype('Individual'));
 
   if ($html) {
-    $html           = civicrm_add_jquery($html);
-    $output['crm_profiles'] = array(
-        '#type' => 'fieldset',
-        '#title' => t('CRM profiles'),
-        '#weight' => 100,
-        '#collapsible' => FALSE,
-        '#collapsed' => FALSE,
-      );
-    $output['crm_profiles']['civicrm-profile-register'] = array(
+    $html = civicrm_add_jquery($html);
+    $form['civicrm_profile_register'] = array(
       '#type' => 'item',
       '#markup' => $html,
-      '#value' => $html,
       '#weight' => 1,
     );
   }
-  return $output;
 }
 
 /**
@@ -995,6 +971,9 @@ function civicrm_add_jquery(&$html) {
   return $html;
 }
 
+/**
+ * Implements hook_form_alter().
+ */
 function civicrm_form_alter(&$form, &$form_state, $formID) {
   switch ($formID) {
     case 'user_admin_permissions':
@@ -1007,14 +986,6 @@ function civicrm_form_alter(&$form, &$form_state, $formID) {
         }
         CRM_Core_BAO_Navigation::resetNavigation();
       }
-      break;
-
-    case 'user_register_form':
-      $form['#attributes']['enctype'] = 'multipart/form-data';
-      $form['#validate'][] = 'civicrm_user_form_validate';
-      $output = civicrm_register_data($form['#user'], FALSE);
-      $form = array_merge($form, $output);
-      $form_state['no_cache'] = TRUE;
       break;
 
     default:

--- a/civicrm_user.inc
+++ b/civicrm_user.inc
@@ -65,20 +65,20 @@ function civicrm_user_insert($account) {
     return;
   }
 
-  $config = CRM_Core_Config::singleton();
-  if ($config->inCiviCRM) {
+  CRM_Core_BAO_UFMatch::synchronize($account, FALSE, 'Backdrop', civicrm_get_ctype('Individual'));
+
+  // As per CRM-7858, the email address in CiviCRM isn't always set
+  // with a call to synchronize(). So we force this through.
+  $contact_id = CRM_Core_BAO_UFMatch::getContactId($account->id());
+  if (empty($contact_id)) {
     return;
   }
+  CRM_Core_BAO_UFMatch::updateContactEmail($contact_id, trim($account->mail));
 
-  // Did civicrm generate this page, or is it via a user hook?
-  if (civicrm_on_user_page()) {
-    civicrm_register_data($account, FALSE);
-  }
-  else {
-    CRM_Core_BAO_UFMatch::synchronize($account, FALSE, 'Backdrop',
-      civicrm_get_ctype('Individual')
-    );
-  }
+  // Process any profile form fields that may have been submitted.
+  // In particular, this will pick up form fields that were submitted on the user_registration page.
+  CRM_Core_BAO_UFGroup::getEditHTML($contact_id, '', 2, TRUE, FALSE, NULL, FALSE, civicrm_get_ctype('Individual'));
+
 }
 
 /**


### PR DESCRIPTION
Addresses Issue #22. Now it adds civi info to second contact. The code more closely matches Drupal 8's integration with Civi.

It still creates two contacts but the fields are no longer left empty on the second contact.

(It's a mystery how Civi is processing these forms and why it wasn't creating duplicates on Drupal 7).