### PR TITLE
CRM-21619 - Fix civicrm.info to allow Project Installer to install CiviCRM

### DIFF
--- a/civicrm.info
+++ b/civicrm.info
@@ -4,4 +4,5 @@ version = 1.x-4.7
 package = CiviCRM
 backdrop = 1.x
 project = civicrm
-php = 5.3
+php = 5.4
+type = module


### PR DESCRIPTION
To replicate this problem, follow the documented Backdrop installation instructions, particularly:
* Install a fresh copy of Backdrop.
* Go to **Functionality » Install New Modules**.
* Click on **Manual Installation**.
* Select either "Install from a URL" or "Upload a Module, Theme, or Layout Archive to Install".

## Expected Behavior
* CiviCRM is added to the list of installed modules.

## Actual behavior
* You receive the following error:
```
The info file (temporary://update-extraction-d681262a/civicrm/backdrop/civicrm.info) does not define a 'type' attribute.
```

## Note
I also incremented the minimum version of PHP to be accurate.