### PR TITLE
Make error more pleasing / fix Backdrop install link

### DIFF
--- a/civicrm.install
+++ b/civicrm.install
@@ -37,7 +37,7 @@ function civicrm_install() {
 }
 
 /**
- * Implements hook_uninstall( )
+ * Implements hook_uninstall().
  */
 function civicrm_uninstall() {
   require_once 'civicrm.module';

--- a/civicrm.install
+++ b/civicrm.install
@@ -64,15 +64,15 @@ function civicrm_requirements($phase) {
     $civicrm_path = substr_replace($civicrm_path, '', $pos, strlen($civicrm_path));
   }
 
-  $url = $base_url . '/' . $civicrm_path . 'install/index.php';
+  $url = $base_url . '/' . $civicrm_path . 'install/index.php?civicrm_install_type=backdrop';
 
   $settings = glob('civicrm.settings.php');
   $problems = array();
   if (empty($settings) && $phase == 'install') {
     $problems[] = array(
-      'title' => t('CiviCRM settings does not exist'),
+      'title' => t('CiviCRM settings does not exist.'),
       'value' =>
-      t('CiviCRM settings file does not exist. It should be created by CiviCRM <a href="!link">install</a>',
+      t('Please <a href="!link">install</a> CiviCRM to create the settings file.',
         array('!link' => $url)),
       'severity' => REQUIREMENT_ERROR,
     );

--- a/civicrm.install
+++ b/civicrm.install
@@ -23,7 +23,7 @@
  | GNU Affero General Public License or the licensing of CiviCRM,     |
  | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
  +--------------------------------------------------------------------+
-*/
+ */
 
 /**
  *
@@ -37,7 +37,7 @@ function civicrm_install() {
 }
 
 /**
- * Implementation of hook_uninstall( )
+ * Implements hook_uninstall( )
  */
 function civicrm_uninstall() {
   require_once 'civicrm.module';
@@ -60,7 +60,7 @@ function civicrm_requirements($phase) {
   //remove the last occurrence of 'backdrop' from path
   $pos = strrpos($civicrm_path, 'backdrop');
 
-  if ($pos !== false) {
+  if ($pos !== FALSE) {
     $civicrm_path = substr_replace($civicrm_path, '', $pos, strlen($civicrm_path));
   }
 
@@ -69,10 +69,11 @@ function civicrm_requirements($phase) {
   $settings = glob('civicrm.settings.php');
   $problems = array();
   if (empty($settings) && $phase == 'install') {
+    $t = get_t();
     $problems[] = array(
-      'title' => t('CiviCRM settings does not exist.'),
+      'title' => $t('CiviCRM settings does not exist.'),
       'value' =>
-      t('Please <a href="!link">install</a> CiviCRM to create the settings file.',
+      $t('Please <a href="!link">install</a> CiviCRM to create the settings file.',
         array('!link' => $url)),
       'severity' => REQUIREMENT_ERROR,
     );


### PR DESCRIPTION
I stumbled upon this error and it could be cleaned up a bit. 

![screen shot 2018-03-08 at 3 55 44 pm](https://user-images.githubusercontent.com/871421/37179119-368abccc-22ea-11e8-99d9-43f8b15661d6.jpg)

The way that Backdrop generates this is duplicating the title with the first part of the error message, so I've cleaned that up. Also the install link goes to a page that gives an error because it doesn't include the Backdrop flag on the end of the URL, so I've fixed that, too.

