### PR TITLE
#68: Allow formatting created date in Views

### DIFF
--- a/modules/views/components/civicrm.core.inc
+++ b/modules/views/components/civicrm.core.inc
@@ -709,6 +709,22 @@ function _civicrm_core_data(&$data, $enabled) {
       'handler' => 'civicrm_handler_sort_date',
     ),
   );
+  // Created date
+  $data['civicrm_contact']['created_date'] = array(
+    'title' => t('Created date'),
+    'help' => t("The date the contact's record was created."),
+    'field' => array(
+      'handler' => 'civicrm_handler_field_datetime',
+      'click sortable' => TRUE,
+    ),
+    'filter' => array(
+      'handler' => 'civicrm_handler_filter_datetime',
+      'is date' => TRUE,
+    ),
+    'sort' => array(
+      'handler' => 'civicrm_handler_sort_date',
+    ),
+  );
   // Image URL
   $data['civicrm_contact']['image_URL'] = array(
     'title' => t('Contact Image'),


### PR DESCRIPTION
Without adding this explicitly I found that the created date could be added to a view, but no date formatting options were available (as they were for the modified date). This matches the functionality for the created date with what is there currently for the modified date.