### PR TITLE
Bump Minimum PHP Version to match what is required as per core install

### DIFF
--- a/civicrm.info
+++ b/civicrm.info
@@ -4,5 +4,5 @@ version = 1.x-4.7
 package = CiviCRM
 backdrop = 1.x
 project = civicrm
-php = 5.4
+php = 5.6
 type = module


### PR DESCRIPTION
This updates the PHP Version specification as per https://github.com/civicrm/civicrm-drupal/pull/567