### PR TITLE
90 module enable civicrtheme

### DIFF
--- a/drush/civicrm.drush.inc
+++ b/drush/civicrm.drush.inc
@@ -340,7 +340,7 @@ function drush_civicrm_install() {
   // generate civicrm.settings.php file
   _civicrm_generate_settings_file($dbuser, $dbpass, $dbhost, $dbname, $modPath);
 
-  module_enable(array('civicrm'));
+  module_enable(array('civicrm', 'civicrmtheme'));
 
   drush_log(dt("CiviCRM installed."), 'ok');
 }

--- a/drush/civicrm.drush.inc
+++ b/drush/civicrm.drush.inc
@@ -382,28 +382,30 @@ function _civicrm_install_db($dbuser, $dbpass, $dbhost, $dbname,
   drush_log(dt("Loading CiviCRM database structure .."));
   civicrm_source($dsn, $sqlPath . '/civicrm.mysql');
   drush_log(dt("Loading CiviCRM database with required data .."));
-  // testing the translated sql files availability
-  $data_file = $sqlPath . '/civicrm_data.mysql';
-  $acl_file = $sqlPath . '/civicrm_acl.mysql';
-  if ($lang != '') {
-    if (file_exists($sqlPath . '/civicrm_data.' . $lang . '.mysql')
-      and file_exists($sqlPath . '/civicrm_acl.' . $lang . '.mysql')
-      and $lang != ''
-    ) {
-      $data_file = $sqlPath . '/civicrm_data.' . $lang . '.mysql';
-      $acl_file = $sqlPath . '/civicrm_acl.' . $lang . '.mysql';
-    }
-    else {
-      drush_log(dt("No sql files could be retrieved for \"" . $lang .
-        "\", using default language."
-      ), 'warning');
-    }
-  }
-  civicrm_source($dsn, $data_file);
-  civicrm_source($dsn, $acl_file);
 
   if ($loadGeneratedData) {
+    drush_log(dt("Loading in generated data"));
     civicrm_source($dsn, $sqlPath . DIRECTORY_SEPARATOR . 'civicrm_generated.mysql', TRUE);
+  }else{
+    // testing the translated sql files availability
+    $data_file = $sqlPath . '/civicrm_data.mysql';
+    $acl_file = $sqlPath . '/civicrm_acl.mysql';
+    if ($lang != '') {
+        if (file_exists($sqlPath . '/civicrm_data.' . $lang . '.mysql')
+            and file_exists($sqlPath . '/civicrm_acl.' . $lang . '.mysql')
+            and $lang != ''
+        ) {
+            $data_file = $sqlPath . '/civicrm_data.' . $lang . '.mysql';
+            $acl_file = $sqlPath . '/civicrm_acl.' . $lang . '.mysql';
+        }
+        else {
+            drush_log(dt("No sql files could be retrieved for \"" . $lang .
+                         "\", using default language."
+            ), 'warning');
+        }
+    }
+      civicrm_source($dsn, $data_file);
+      civicrm_source($dsn, $acl_file);
   }
   drush_log(dt("CiviCRM database loaded successfully."), 'ok');
 }


### PR DESCRIPTION
quick fix to enable the civicrmtheme module when running civicrm install drush command.  This is the default behaviour when installing civicrm manually so we should mirror that.