### PR TITLE
Civicrmtheme enabled when drush install [issue #90]

### DIFF
--- a/drush/civicrm.drush.inc
+++ b/drush/civicrm.drush.inc
@@ -340,7 +340,7 @@ function drush_civicrm_install() {
   // generate civicrm.settings.php file
   _civicrm_generate_settings_file($dbuser, $dbpass, $dbhost, $dbname, $modPath);
 
-  module_enable(array('civicrm'));
+  module_enable(array('civicrm', 'civicrmtheme'));
 
   drush_log(dt("CiviCRM installed."), 'ok');
 }


### PR DESCRIPTION
quick fix to enable the civicrmtheme module when running civicrm install drush command.  This is the default behaviour when installing civicrm manually so we should mirror that.