### PR TITLE
#94 load generated data can now be set explicitly with true|false

### DIFF
--- a/drush/civicrm.drush.inc
+++ b/drush/civicrm.drush.inc
@@ -311,7 +311,7 @@ function drush_civicrm_install() {
   $backdropRoot = drush_get_context('DRUSH_BACKDROP_ROOT');
   $modPath = "$backdropRoot/$crmpath";
   $lang = drush_get_option('lang', '');
-  $loadGeneratedData = drush_get_option('load_generated_data', FALSE);
+  $loadGeneratedData = filter_var(drush_get_option('load_generated_data', FALSE), FILTER_VALIDATE_BOOLEAN);
 
   if (!is_dir("$modPath/civicrm")) {
     // extract tarfile at right place


### PR DESCRIPTION
We can now explicitly set the value of the var load_generated_data when using drush command ci (civicrm-install) which before would be true whatever value was passed.  Now setting the variable to true|false, yes|no, on|off, 1|0 will result in a boolean true or false.

This addresses issues #94  