### PR TITLE
updated bootstrap constant name to match that in BackdropBoot

### DIFF
--- a/drush/civicrm.drush.inc
+++ b/drush/civicrm.drush.inc
@@ -181,7 +181,7 @@ function civicrm_drush_command() {
     // explicit callback declaration and non-standard name to avoid collision with "sql-conf"
     'callback' => 'drush_civicrm_sqlconf',
     'description' => 'Print CiviCRM database connection details.',
-    'bootstrap' => DRUSH_BOOTSTRAP_BACKDROP_CONFIGURATION,
+    'bootstrap' => BACKDROP_BOOTSTRAP_CONFIGURATION,
   );
   $items['civicrm-sql-connect'] = array(
     // explicit callback declaration and non-standard name to avoid collision with "sql-connect"
@@ -224,7 +224,7 @@ function civicrm_drush_command() {
     'callback' => 'drush_civicrm_sqlcli',
     'description' => "Open a SQL command-line interface using CiviCRM's credentials.",
     'aliases' => array('cvsqlc'),
-    'bootstrap' => DRUSH_BOOTSTRAP_BACKDROP_CONFIGURATION,
+    'bootstrap' => BACKDROP_BOOTSTRAP_CONFIGURATION,
   );
   $items['civicrm-sql-rebuild-triggers'] = array(
     'description' => 'Rebuild SQL triggers',


### PR DESCRIPTION
we were getting errors 
```
 Use of undefined constant DRUSH_BOOTSTRAP_BACKDROP_CONFIGURATION -     [warning]
assumed 'DRUSH_BOOTSTRAP_BACKDROP_CONFIGURATION' (this will throw an Error in a future version of PHP) civicrm.drush.inc:185
```

have updated the bootstrap configuration constant to match that in BackdropBoot https://github.com/backdrop-contrib/drush/blob/1d4b9ba7dcbe6f8d84ca38d34283a5d18346af6d/BackdropBoot.php#L316 and tested against this command which gave a good output:

```
vendor/bin/drush civicrm-sql-conf --root=build
Array
(
    [driver] => mysql
    [database] => backdropdb
    [username] => backdropuser
    [password] => top-secret
    [host] => backdropdbserver
    [port] => 3306
    [prefix] => 
    [charset] => utf8mb4
)
```
