### PR TITLE
drush civicrm-install now accepts optional site_key

### DIFF
--- a/drush/civicrm.drush.inc
+++ b/drush/civicrm.drush.inc
@@ -86,6 +86,7 @@ function civicrm_drush_command() {
       'site_url' => 'Base Url for your backdrop/CiviCRM website without http (e.g. mysite.com)',
       'ssl' => 'Using ssl for your backdrop/CiviCRM website if set to on (e.g. --ssl=on)',
       'load_generated_data' => 'Loads the demo generated data. Defaults to FALSE.',
+      'site_key' => 'Define a site key, suggest md5 hash. Otional, install will generate if not present',
     ),
     'aliases' => array('cvi'),
   );
@@ -512,6 +513,10 @@ function _civicrm_generate_settings_file($dbuser, $dbpass, $dbhost, $dbname, $mo
     $cms = $v['cms'];
   }
 
+  if (!$sitekey = drush_get_option('site_key', FALSE)) {
+      $sitekey = md5(uniqid('', TRUE) . $baseUrl);
+  }
+      
   $params = array(
     'crmRoot' => $crmPath,
     'templateCompileDir' => "$backdropRoot/$siteRoot/files/civicrm/templates_c",
@@ -526,7 +531,7 @@ function _civicrm_generate_settings_file($dbuser, $dbpass, $dbhost, $dbname, $mo
     'CMSdbPass' => $db_spec['password'],
     'CMSdbHost' => $db_spec['host'],
     'CMSdbName' => $db_spec['database'],
-    'siteKey' => md5(uniqid('', TRUE) . $baseUrl),
+    'siteKey' => $sitekey,
   );
   $str = file_get_contents($settingsTplFile);
   foreach ($params as $key => $value) {

--- a/drush/civicrm.drush.inc
+++ b/drush/civicrm.drush.inc
@@ -511,7 +511,7 @@ function _civicrm_generate_settings_file($dbuser, $dbpass, $dbhost, $dbname, $mo
     require_once "$crmPath/civicrm-version.php";
     $v = civicrmVersion();
     $cms = $v['cms'];
-  } 
+  }
   if (!$sitekey = drush_get_option('site_key', FALSE)) {
     $sitekey = md5(rand() . mt_rand() . rand() . uniqid('', TRUE) . $baseUrl);
   }

--- a/drush/civicrm.drush.inc
+++ b/drush/civicrm.drush.inc
@@ -511,9 +511,9 @@ function _civicrm_generate_settings_file($dbuser, $dbpass, $dbhost, $dbname, $mo
     require_once "$crmPath/civicrm-version.php";
     $v = civicrmVersion();
     $cms = $v['cms'];
-  }
+  } 
   if (!$sitekey = drush_get_option('site_key', FALSE)) {
-      $sitekey = md5(rand() . mt_rand() . rand() . uniqid('', TRUE) . $baseUrl);
+    $sitekey = md5(rand() . mt_rand() . rand() . uniqid('', TRUE) . $baseUrl);
   }
   $params = array(
     'crmRoot' => $crmPath,

--- a/drush/civicrm.drush.inc
+++ b/drush/civicrm.drush.inc
@@ -513,9 +513,8 @@ function _civicrm_generate_settings_file($dbuser, $dbpass, $dbhost, $dbname, $mo
     $cms = $v['cms'];
   }
   if (!$sitekey = drush_get_option('site_key', FALSE)) {
-    $sitekey = md5(rand() . mt_rand() . rand() . uniqid('', TRUE) . $baseUrl);
+      $sitekey = md5(rand() . mt_rand() . rand() . uniqid('', TRUE) . $baseUrl);
   }
-      
   $params = array(
     'crmRoot' => $crmPath,
     'templateCompileDir' => "$backdropRoot/$siteRoot/files/civicrm/templates_c",

--- a/drush/civicrm.drush.inc
+++ b/drush/civicrm.drush.inc
@@ -512,9 +512,8 @@ function _civicrm_generate_settings_file($dbuser, $dbpass, $dbhost, $dbname, $mo
     $v = civicrmVersion();
     $cms = $v['cms'];
   }
-
   if (!$sitekey = drush_get_option('site_key', FALSE)) {
-      $sitekey = md5(uniqid('', TRUE) . $baseUrl);
+    $sitekey = md5(rand() . mt_rand() . rand() . uniqid('', TRUE) . $baseUrl);
   }
       
   $params = array(


### PR DESCRIPTION
When installing civicrm it is possible to set the site_key in civicrm.settings.php manually, the comment there gives guidance how to do this (eg. best to use md5sum etc).

When using drush to install civicrm there is no option to do this.  This PR fixes that and adds an optional parameter site_key which if present will add the parameter to the civicrm.settings.php 

This should be a non-breaking change to any code that's out there but adds needed functionality.  I have tested with and without specifying a key and all works as expected.