### PR TITLE
Installation - Support "activate first" w/setup UI

### DIFF
--- a/civicrm.install
+++ b/civicrm.install
@@ -62,34 +62,9 @@ function civicrm_uninstall() {
 }
 
 function civicrm_requirements($phase) {
-  global $base_url;
-  $civicrm_path = backdrop_get_path('module', 'civicrm');
-
-  //remove the last occurrence of 'backdrop' from path
-  $pos = strrpos($civicrm_path, 'backdrop');
-
-  if ($pos !== FALSE) {
-    $civicrm_path = substr_replace($civicrm_path, '', $pos, strlen($civicrm_path));
-  }
-
-  $url = $base_url . '/' . $civicrm_path . 'install/index.php?civicrm_install_type=backdrop';
-
   $requirements = array();
   $t = get_t();
   switch ($phase) {
-    case 'install':
-      $settings = glob('civicrm.settings.php');
-      if (empty($settings)) {
-        $requirements[] = array(
-          'title' => $t('CiviCRM settings does not exist'),
-          'value' =>
-          $t('CiviCRM settings file does not exist. It should be created by CiviCRM <a href="!link">install</a>',
-            array('!link' => $url)),
-          'severity' => REQUIREMENT_ERROR,
-        );
-      }
-      break;
-
     case 'runtime':
       if (!civicrm_initialize()) {
         return;

--- a/civicrm.install
+++ b/civicrm.install
@@ -36,6 +36,11 @@ function civicrm_enable() {
   menu_link_save($options);
 
   if (!civicrm_initialize()) {
+    $installLink = url('civicrm/setup');
+    $message = t('<p class="error"><strong>CiviCRM is almost ready.</strong> You must <a href="@url">configure CiviCRM</a> for it to work.</p>', [
+      '@url' => $installLink,
+    ]);
+    backdrop_set_message($message, 'status', FALSE);
     return;
   }
 
@@ -67,7 +72,15 @@ function civicrm_requirements($phase) {
   switch ($phase) {
     case 'runtime':
       if (!civicrm_initialize()) {
-        return;
+        $installLink = url('civicrm/setup');
+        $requirements['civicrm'] = array(
+          'title' => $t("CiviCRM"),
+          'severity' => REQUIREMENT_ERROR,
+          'value' => $t('<p class="error"><strong>CiviCRM is almost ready.</strong> You must <a href="@url">configure CiviCRM</a> for it to work.</p>', [
+            '@url' => $installLink,
+          ]),
+        );
+        return $requirements;
       }
       $vc = new CRM_Utils_VersionCheck();
       $vc->fetch();

--- a/civicrm.module
+++ b/civicrm.module
@@ -113,9 +113,6 @@ function civicrm_block_view($delta = '0') {
  * Implements hook_menu().
  */
 function civicrm_menu() {
-  if (!civicrm_initialize()) {
-    return;
-  }
   $items['civicrm'] = array(
     'title' => 'CiviCRM',
     'access callback' => TRUE,
@@ -266,13 +263,16 @@ function civicrm_initialize() {
       )
     );
 
-    if (!include_once $settingsFile) {
+    $loadedSettings = (bool) @include_once $settingsFile;
+    if (!$loadedSettings) {
       $failure = TRUE;
-      $message = t("<strong><p class='error'> Oops! - The CiviCRM settings file (civicrm.settings.php) was not found in the expected location (!1) </p><p class='error'> !2 </p></strong>", array(
-        '!1' => $settingsFile,
-        '!2' => $errorMsgAdd,
-      ));
-      backdrop_set_message($message);
+      if (user_access('administer modules')) {
+        $installLink = url('civicrm');
+        $message = t('<p class="error"><strong>CiviCRM is almost ready.</strong> You must <a href="@url">configure CiviCRM</a> for it to work.</p>', [
+          '@url' => $installLink,
+        ]);
+        backdrop_set_message($message);
+      }
       return FALSE;
     }
 
@@ -455,7 +455,9 @@ function civicrm_invoke() {
 
   // make sure the system is initialized
   if (!civicrm_initialize()) {
-    return backdrop_not_found();
+    require_once __DIR__ . '/civicrm.setup.inc';
+    // NOTE: The setup page has a built-in authorization check.
+    return civicrm_setup_page();
   }
 
   civicrm_cache_disable();

--- a/civicrm.module
+++ b/civicrm.module
@@ -989,7 +989,9 @@ function civicrm_form_alter(&$form, &$form_state, $formID) {
 function civicrm_user_admin_permissions_submit($form, &$form_state) {
   $role = $form_state['values']['roles']['anonymous'];
 
-  civicrm_initialize();
+  if (!civicrm_initialize()) {
+    return;
+  }
 
   $permissions = $form_state['values'][$role->name];
   $warning_permissions = CRM_Core_Permission::validateForPermissionWarnings($permissions);
@@ -1099,7 +1101,10 @@ function _civicrm_filter_tips($filter, $format, $long = FALSE) {
  * @return bool|mixed|string
  */
 function _civicrm_filter_process($text, $filter, $format, $langcode, $cache, $cache_id) {
-  civicrm_initialize();
+  if (!civicrm_initialize()) {
+    return t('(Content unavailable. CiviCRM is not installed.)');
+  }
+
   $config = CRM_Core_Config::singleton();
   $smarty = CRM_Core_Smarty::singleton();
   // as this file is not a class (not sure why) we need the require once
@@ -1292,7 +1297,9 @@ function civicrm_reviews() {
  * Implements hook_modules_installed().
  */
 function civicrm_modules_installed($modules) {
-  civicrm_initialize();
+  if (!civicrm_initialize()) {
+    return;
+  }
   CRM_Core_Invoke::rebuildMenuAndCaches(TRUE);
 }
 
@@ -1300,7 +1307,9 @@ function civicrm_modules_installed($modules) {
  * Implements hook_modules_enabled().
  */
 function civicrm_modules_enabled($modules) {
-  civicrm_initialize();
+  if (!civicrm_initialize()) {
+    return;
+  }
   CRM_Core_Invoke::rebuildMenuAndCaches(TRUE);
 }
 
@@ -1308,7 +1317,9 @@ function civicrm_modules_enabled($modules) {
  * Implements hook_modules_disabled().
  */
 function civicrm_modules_disabled($modules) {
-  civicrm_initialize();
+  if (!civicrm_initialize()) {
+    return;
+  }
   CRM_Core_Invoke::rebuildMenuAndCaches(TRUE);
 }
 
@@ -1316,7 +1327,9 @@ function civicrm_modules_disabled($modules) {
  * Implements hook_modules_uninstalled().
  */
 function civicrm_modules_uninstalled($modules) {
-  civicrm_initialize();
+  if (!civicrm_initialize()) {
+    return;
+  }
   CRM_Core_Invoke::rebuildMenuAndCaches(TRUE);
 }
 

--- a/civicrm.module
+++ b/civicrm.module
@@ -149,6 +149,10 @@ function civicrm_menu() {
  * Translating profile menu title dynamicaly to overide caching
  */
 function civicrm_menu_alter(&$items) {
+  if (!civicrm_initialize()) {
+    return;
+  }
+
   $profiles = civicrm_user_profiles();
   foreach ($profiles as $profile) {
     $path = 'user/%user/edit/' . $profile['name'];

--- a/civicrm.module
+++ b/civicrm.module
@@ -120,6 +120,15 @@ function civicrm_menu() {
     'type' => 4,
     'weight' => 0,
   );
+  $items['civicrm/setup'] = array(
+    'title' => 'CiviCRM Setup',
+    'access callback' => TRUE,
+    'page callback' => 'civicrm_setup_page',
+    'file' => 'civicrm.setup.inc',
+    'access arguments' => array('administer modules'),
+    'type' => 4,
+    'weight' => 0,
+  );
   // administration section for civicrm integration modules.
   $items['admin/config/civicrm'] = array(
     'title' => 'CiviCRM',
@@ -266,13 +275,6 @@ function civicrm_initialize() {
     $loadedSettings = (bool) @include_once $settingsFile;
     if (!$loadedSettings) {
       $failure = TRUE;
-      if (user_access('administer modules')) {
-        $installLink = url('civicrm');
-        $message = t('<p class="error"><strong>CiviCRM is almost ready.</strong> You must <a href="@url">configure CiviCRM</a> for it to work.</p>', [
-          '@url' => $installLink,
-        ]);
-        backdrop_set_message($message);
-      }
       return FALSE;
     }
 

--- a/civicrm.setup.inc
+++ b/civicrm.setup.inc
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * (Page callback)
+ *
+ * @return string
+ */
+function civicrm_setup_page() {
+  $coreUrl = dirname(file_create_url(backdrop_get_path('module', 'civicrm')));
+  $corePath = dirname(__DIR__);
+  $classLoader = implode(DIRECTORY_SEPARATOR, [$corePath, 'CRM', 'Core', 'ClassLoader.php']);
+
+  if (file_exists($classLoader)) {
+    require_once $classLoader;
+    CRM_Core_ClassLoader::singleton()->register();
+    \Civi\Setup::assertProtocolCompatibility(1.0);
+    \Civi\Setup::init([
+      // This is just enough information to get going. Backdrop.civi-setup.php does more scanning.
+      'cms' => 'Backdrop',
+      'srcPath' => $corePath,
+    ], NULL, _civicrm_setup_logger());
+    $ctrl = \Civi\Setup::instance()->createController()->getCtrl();
+    $ctrl->setUrls(array(
+      'ctrl' => url('civicrm'),
+      'res' => $coreUrl . '/setup/res/',
+      'jquery.js' => $coreUrl . '/bower_components/jquery/dist/jquery.min.js',
+      'font-awesome.css' => $coreUrl . '/bower_components/font-awesome/css/font-awesome.min.css',
+      // Not used? 'finished' => url('civicrm/dashboard', ['query' => ['reset' => 1],]),
+    ));
+    // return _civicrm_setup_runCtrl($ctrl);
+    \Civi\Setup\BasicRunner::run($ctrl);
+    exit();
+  }
+  else {
+    backdrop_set_message(t('Cannot perform setup for CiviCRM. The file "@file" is missing.', [
+      '@file' => $classLoader,
+    ]), 'error');
+    return '';
+  }
+}
+
+/**
+ * @return NULL|\Psr\Log\LoggerInterface
+ */
+function _civicrm_setup_logger() {
+  return NULL;
+  //$logger = new class extends \Psr\Log\AbstractLogger {
+  //  public function log($level, $message, array $context = array()) {
+  //    echo "<tt>$message</tt><br>\n";
+  //  }
+  //};
+  //return $logger;
+}
+
+///**
+// * @param \Civi\Setup\UI\SetupControllerInterface $ctrl
+// * @return mixed
+// */
+//function _civicrm_setup_runCtrl($ctrl) {
+//  \Civi\Setup::assertProtocolCompatibility(1.1);
+//  $method = $_SERVER['REQUEST_METHOD'];
+//
+//  /** @var \Civi\Setup\UI\SetupResponse $response */
+//  $response = $ctrl->run($method, ($method === 'GET' ? $_GET : $_POST));
+//
+//  if ($response->isComplete) {
+//    \Civi\Setup\BasicRunner::send($ctrl, $response);
+//    exit();
+//  }
+//
+//  foreach ($response->headers as $k => $v) {
+//    backdrop_add_http_header($k, $v, TRUE);
+//  }
+//
+//  foreach ($response->assets as $asset) {
+//    switch ($asset['type']) {
+//      case 'script-url':
+//        backdrop_add_js($asset['url'], 'external');
+//        break;
+//
+//      case 'script-code':
+//        backdrop_add_js($asset['code'], 'inline');
+//        break;
+//
+//      case 'style-url':
+//        backdrop_add_css($asset['url'], 'external');
+//        break;
+//
+//      default:
+//        throw new \Exception("Unrecognized page asset: " . $asset['type']);
+//    }
+//  }
+//
+//  return $response->body;
+//}


### PR DESCRIPTION
Overview
----------

This adds support for installing CiviCRM-Backdrop through the [Setup API](https://docs.civicrm.org/dev/en/latest/framework/setup/new-installer/). Most notable changes:

* Better layout and more useful options on the installation screen
* Extensible installation logic - under the hood, this installer can initialize settings, toggle extensions, etc.
* Reusable installation logic - can run the same installation code for CLI and web UI
* No need to bypass regular module activation or bypass router (no need for `install/index.php` entry-point)

Before
------

The sysadmin downloads the CiviCRM module - but they must *not* install it. Instead, navigate to this path:

```
http://example.org/modules/civicrm/install/index.php?civicrm_install_type=backdrop
```

This is a special, standalone entry-point.

After
-----

After downloading the CiviCRM module, you simply enable it like any module. Then use any link to open a CiviCRM page (e.g. there are links in the post-install status-message and in the main menu). The page will display the setup screen.

![Screen Shot 2020-07-03 at 11 17 37 PM](https://user-images.githubusercontent.com/1336047/86506346-72a4f480-bd83-11ea-88c8-3c986e4a7ba6.png)

Slightly better demo: http://think.hm/tmp/Backdrop-Civicrm-Setup.mp4

Technical Details
-----------------

1. The old install screen is still available as a fallback (in case there's some edge-case that got missed).
2. The basic gist of this change is:
    * Ensure that all CiviCRM-Backdrop hooks fail gracefully (in the absence of `civicrm.settings.php`). Most already do - there were just a couple oddballs.
    * Update the handling of `civicrm/*` URLs. If CiviCRM cannot initialize, then show the [civicrm-setup web installer](https://docs.civicrm.org/dev/en/latest/framework/setup/new-installer/#web-installer-api).
3. This is the same API used in [the newer Civi-WP installer](https://github.com/civicrm/civicrm-wordpress/blob/5.28/civicrm.php#L1189-L1207). (*Note: For historical reasons, the Civi-WP has a few extra contingencies that aren't needed here.*)
4. When testing/`r-run`ning, here are some of things that I tried:
    * Enable the module and try to view it as regular/non-admin user. Regular users cannot perform installation.
    * Install via web UI 
    * Install via CLI (`cv core:install -vv --cms-base-url=http://bcmaster.bknix:8001`), with the `civicrm.module` enabled or disabled
    * Install in US English or French.
4. During development, my workflow went a bit like this:
    1. Create Backdrop site with CiviCRM codebase -- but without installing. (*I specifically used a modified `civibuild` with the `backdrop-clean` type - ie hack `app/config/backdrop-clean/install.sh` to skip the scripted `civicrm_install`, etal. Then run `civibuild create bcmaster` or `civibuild reinstall bcmaster`*)
    2. Login.
    3. Make a new DB snapshot (eg `civibuild snapshot bcmaster`). (This way my login-session is part of the snapshot.)
    4. Repeatedly do the following:
        * Edit code
        * Use the installer - and see how it goes.
        * Cleanup: `./bin/cv.phar core:uninstall -f ; civibuild restore bcmaster ; rm -rf ~/bknix/build/bcmaster/web/files/civicrm/`
5. This depends on another PR for civicrm-core: https://github.com/civicrm/civicrm-core/pull/17749