### PR TITLE
dev/core#2258 Define CIVICRM_CRED_KEYS during drush installation

### DIFF
--- a/drush/civicrm.drush.inc
+++ b/drush/civicrm.drush.inc
@@ -508,7 +508,8 @@ function _civicrm_generate_settings_file($dbuser, $dbpass, $dbhost, $dbname, $mo
     'CMSdbPass' => $db_spec['password'],
     'CMSdbHost' => $db_spec['host'],
     'CMSdbName' => $db_spec['database'],
-    'siteKey' => md5(uniqid('', TRUE) . $baseUrl),
+    'siteKey' => preg_replace(';[^a-zA-Z0-9];', '', base64_encode(random_bytes(32))),
+    'credKeys' => 'aes-cbc:hkdf-sha256:' . preg_replace(';[^a-zA-Z0-9];', '', base64_encode(random_bytes(32))),
   );
   $str = file_get_contents($settingsTplFile);
   foreach ($params as $key => $value) {


### PR DESCRIPTION
Backdrop version of https://github.com/civicrm/civicrm-drupal/pull/636

Overview
----------------------------------------
When using `drush civivcrm-install`, the `civicrm.settings.php` should have a credential-key.

See also: civicrm/civicrm-core#19349 and https://lab.civicrm.org/dev/core/-/issues/2258

Before
----------------------------------------

Blank key

After
----------------------------------------

Random key

@totten 