### PR TITLE
dev/core#2204 Update minimum php install to be 7.2

### DIFF
--- a/civicrm.info
+++ b/civicrm.info
@@ -4,7 +4,7 @@ version = 1.x-4.7
 package = CiviCRM
 backdrop = 1.x
 project = civicrm
-php = 7.1
+php = 7.2
 type = module
 
 stylesheets[all][] = civicrm_backdrop.css

--- a/civicrm.module
+++ b/civicrm.module
@@ -43,7 +43,7 @@ define('CIVICRM_UF_HEAD', TRUE);
  * @see CRM_Upgrade_Incremental_General::MIN_INSTALL_PHP_VER
  * @see CiviBackdrop\PhpVersionTest::testConstantMatch()
  */
-define('CIVICRM_BACKDROP_PHP_MINIMUM', '7.1.0');
+define('CIVICRM_BACKDROP_PHP_MINIMUM', '7.2.0');
 
 /**
  * Adds CiviCRM CSS and JS resources into the header.


### PR DESCRIPTION
as per https://github.com/civicrm/civicrm-core/pull/19390 and https://github.com/civicrm/civicrm-drupal/pull/637 this makes the minimum PHP version to be 7.2