### PR TITLE
drush install - Bump up entropy for autogenerated creds. Add signing key.

### DIFF
--- a/drush/civicrm.drush.inc
+++ b/drush/civicrm.drush.inc
@@ -508,8 +508,8 @@ function _civicrm_generate_settings_file($dbuser, $dbpass, $dbhost, $dbname, $mo
     'CMSdbPass' => $db_spec['password'],
     'CMSdbHost' => $db_spec['host'],
     'CMSdbName' => $db_spec['database'],
-    'siteKey' => preg_replace(';[^a-zA-Z0-9];', '', base64_encode(random_bytes(32))),
-    'credKeys' => 'aes-cbc:hkdf-sha256:' . preg_replace(';[^a-zA-Z0-9];', '', base64_encode(random_bytes(32))),
+    'siteKey' => preg_replace(';[^a-zA-Z0-9];', '', base64_encode(random_bytes(37))),
+    'credKeys' => 'aes-cbc:hkdf-sha256:' . preg_replace(';[^a-zA-Z0-9];', '', base64_encode(random_bytes(37))),
   );
   $str = file_get_contents($settingsTplFile);
   foreach ($params as $key => $value) {

--- a/drush/civicrm.drush.inc
+++ b/drush/civicrm.drush.inc
@@ -510,6 +510,7 @@ function _civicrm_generate_settings_file($dbuser, $dbpass, $dbhost, $dbname, $mo
     'CMSdbName' => $db_spec['database'],
     'siteKey' => preg_replace(';[^a-zA-Z0-9];', '', base64_encode(random_bytes(37))),
     'credKeys' => 'aes-cbc:hkdf-sha256:' . preg_replace(';[^a-zA-Z0-9];', '', base64_encode(random_bytes(37))),
+    'signKeys' => 'jwt-hs256:hkdf-sha256:' . preg_replace(';[^a-zA-Z0-9];', '', base64_encode(random_bytes(37))),
   );
   $str = file_get_contents($settingsTplFile);
   foreach ($params as $key => $value) {


### PR DESCRIPTION
* Port civicrm/civicrm-core#19568 - Bump up entropy for autogenerated cred keys
* Port civicrm/civicrm-core#19599 - Add autogenerated signing keys for JWT

Note: This is similar to #125, just bumping up numbers and adding another key.
Note: It should be safe to merge in 5.35 or master.