### PR TITLE
Issue 135: Layout access conditions that consider query parameters

### DIFF
--- a/civicrm.module
+++ b/civicrm.module
@@ -182,7 +182,7 @@ function civicrm_layout_access_info() {
     'class' => 'CivicrmChecksumLayoutAccess',
   );
   $info['civicrm_urls'] = array(
-    'title' => t('CiviCRM URLs'),
+    'title' => t('CiviCRM URL path and query'),
     'description' => t('Control access by the path and query parameters of the current CiviCRM page.'),
     'class' => 'CivicrmUrlLayoutAccess',
   );

--- a/civicrm.module
+++ b/civicrm.module
@@ -172,15 +172,19 @@ function civicrm_menu_alter(&$items) {
 /**
  * Implements hook_layout_access_info().
  *
- * Adding a CiviCRM checksum visibility condition.
+ * Adding a CiviCRM checksum visibility condition and a URL condition that
+ * considers the query parameters in the URL.
  */
 function civicrm_layout_access_info() {
-  $info = array(
-    'civicrm_checksum' => array(
-      'title' => t('CiviCRM checksum'),
-      'description' => t('Has the page been loaded with a valid CiviCRM checksum?'),
-      'class' => 'CivicrmChecksumLayoutAccess',
-    ),
+  $info['civicrm_checksum'] = array(
+    'title' => t('CiviCRM checksum'),
+    'description' => t('Has the page been loaded with a valid CiviCRM checksum?'),
+    'class' => 'CivicrmChecksumLayoutAccess',
+  );
+  $info['civicrm_urls'] = array(
+    'title' => t('CiviCRM URLs'),
+    'description' => t('Control access by the path and query parameters of the current CiviCRM page.'),
+    'class' => 'CivicrmUrlLayoutAccess',
   );
   return $info;
 }
@@ -939,6 +943,7 @@ function civicrm_autoload_info() {
 
     // layout visibility conditions handlers
     'CivicrmChecksumLayoutAccess' => 'modules/layouts/plugins/access/civicrm_checksum_layout_access.inc',
+    'CivicrmUrlLayoutAccess' => 'modules/layouts/plugins/access/civicrm_url_layout_access.inc',
 
     // Views plugins are mapped in hook_views_plugins() in civicrm.views.inc.
   );

--- a/modules/layouts/plugins/access/civicrm_url_layout_access.inc
+++ b/modules/layouts/plugins/access/civicrm_url_layout_access.inc
@@ -71,7 +71,7 @@ class CivicrmUrlLayoutAccess extends LayoutAccess {
     $form['civicrm_urls'] = array(
       '#title' => t('CiviCRM URLs'),
       '#type' => 'textarea',
-      '#description' => t('Use this layout only for CiviCRM pages whose path and query parameters match one of the lines above. Query parameter order is irrelevant and extra query parameters in the page URL will be ignored, but all query parameters in the above must be present in the page URL.'),
+      '#description' => t('Use this layout only for CiviCRM pages whose path and query parameters match one of the lines above. Enter just the path and query parameters (not the domain), like "civicrm/event/info?id=1", one URL per line. Query parameter order is irrelevant and extra query parameters in the page URL will be ignored, but all query parameters in the above must be present in the page URL.'),
       '#default_value' => $this->settings['civicrm_urls'],
     );
   }

--- a/modules/layouts/plugins/access/civicrm_url_layout_access.inc
+++ b/modules/layouts/plugins/access/civicrm_url_layout_access.inc
@@ -1,0 +1,87 @@
+<?php
+/**
+ * @file
+ * Plugin to provide access control based on CiviCRM path and query parameters.
+ */
+
+class CivicrmUrlLayoutAccess extends LayoutAccess {
+
+  /**
+   * Constructor for a Layout access rule.
+   */
+  public function __construct($plugin_name, array $data = array()) {
+    parent::__construct($plugin_name, $data);
+    $this->settings += array(
+      'civicrm_urls' => array(),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function summary() {
+    $civicrm_urls = $this->settings['civicrm_urls'];
+    if (!empty($civicrm_urls)) {
+      $lines = array_map('trim', explode("\n", $civicrm_urls));
+      return t('CiviCRM URLs: @urls', array('@urls' => implode(', ', $lines)));
+    }
+    else {
+      return t('CiviCRM URLs: none defined.');
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function checkAccess() {
+    if (arg(0) != 'civicrm') {
+      return FALSE;
+    }
+    if (arg(1) == 'upgrade' || arg(1) == 'ajax') {
+      return FALSE;
+    }
+    if (!civicrm_initialize()) {
+      return FALSE;
+    }
+
+    $paths = array_map('trim', explode("\n", $this->settings['civicrm_urls']));
+    foreach ($paths as $path) {
+      $path_parts = explode('?', $path);
+      if ($_GET['q'] != $path_parts[0]) {
+        continue;
+      }
+      $query_parts = array();
+      parse_str($path_parts[1], $query_parts);
+      $match = TRUE;
+      foreach ($query_parts as $key => $value) {
+        $match &= (isset($_GET[$key]) && $_GET[$key] == $value);
+      }
+      if ($match) {
+        return TRUE;
+      }
+    }
+    return FALSE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function form(&$form, &$form_state) {
+    parent::form($form, $form_state);
+    $form['civicrm_urls'] = array(
+      '#title' => t('CiviCRM URLs'),
+      '#type' => 'textarea',
+      '#description' => t('Use this layout only for CiviCRM pages whose path and query parameters match one of the lines above. Query parameter order is irrelevant and extra query parameters in the page URL will be ignored, but all query parameters in the above must be present in the page URL.'),
+      '#default_value' => $this->settings['civicrm_urls'],
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function formSubmit($form, &$form_state) {
+    parent::formSubmit($form, $form_state);
+    $this->settings['civicrm_urls'] = $form_state['values']['civicrm_urls'];
+  }
+
+}


### PR DESCRIPTION
Fixes https://github.com/civicrm/civicrm-backdrop/issues/135.

Add a LayoutAccess visibility condition that considers path and query parameters.

To test the PR:

1. Create two CiviCRM events (with, for example, event IDs of 1 and 2).
2. Create a layout.
  1. Give it the path `civicrm`.
  2. Give it a visibility condition of type `CiviCRM URLs`, with setting of `civicrm/event/info?id=1`.
  3. Give it a custom block so you can see when it is being used.
3. Visit the event information pages for the two events:
  1. `civicrm/event/info?id=1&reset=1` will show the custom layout.
  2. `civicrm/event/info?id=2&reset=1` will show the regular layout.