### PR TITLE
Fix unreplaced template vars in civicrm.settings.php when using drush installer

### DIFF
--- a/drush/civicrm.drush.inc
+++ b/drush/civicrm.drush.inc
@@ -508,6 +508,9 @@ function _civicrm_generate_settings_file($dbuser, $dbpass, $dbhost, $dbname, $mo
     'CMSdbPass' => $db_spec['password'],
     'CMSdbHost' => $db_spec['host'],
     'CMSdbName' => $db_spec['database'],
+    // These two are only filled in when using the newer civicrm-setup.
+    'dbSSL' => '',
+    'CMSdbSSL' => '',
     'siteKey' => preg_replace(';[^a-zA-Z0-9];', '', base64_encode(random_bytes(37))),
     'credKeys' => 'aes-cbc:hkdf-sha256:' . preg_replace(';[^a-zA-Z0-9];', '', base64_encode(random_bytes(37))),
     'signKeys' => 'jwt-hs256:hkdf-sha256:' . preg_replace(';[^a-zA-Z0-9];', '', base64_encode(random_bytes(37))),


### PR DESCRIPTION
See also civicrm/civicrm-joomla#63

e.g. it leaves behind the literal string %%dbSSL%% in the DSN.