### PR TITLE
Issue 160: Eliminate permissions PHP warnings.

### DIFF
--- a/civicrm.module
+++ b/civicrm.module
@@ -1024,13 +1024,19 @@ function civicrm_form_alter(&$form, &$form_state, $formID) {
  * @param $form_state
  */
 function civicrm_user_admin_permissions_submit($form, &$form_state) {
-  $role = $form_state['values']['roles']['anonymous'];
-
   if (!civicrm_initialize()) {
     return;
   }
 
+  // If we're editing the full permissions matrix or anonymous role permissions,
+  // get the permissions from the form. But if we're only editing a single
+  // (other) role, there's nothing to do here.
+  if (!isset($form_state['values']['roles']['anonymous'])) {
+    return;
+  }
+  $role = $form_state['values']['roles']['anonymous'];
   $permissions = $form_state['values'][$role->name];
+
   $warning_permissions = CRM_Core_Permission::validateForPermissionWarnings($permissions);
   $warning_permission_names = array();
   foreach (module_implements('permission') as $module) {


### PR DESCRIPTION
Fixes https://github.com/civicrm/civicrm-backdrop/issues/160.