### PR TITLE
PHP 8 fixes for civicrm_member_roles

### DIFF
--- a/modules/civicrm_member_roles/civicrm_member_roles.module
+++ b/modules/civicrm_member_roles/civicrm_member_roles.module
@@ -113,7 +113,7 @@ function civicrm_member_roles_sync_user($account) {
   if (!civicrm_initialize()) {
     return;
   }
-  if (in_array('login', config_get('civicrm_member_roles.settings', 'civicrm_member_roles_sync_method'), TRUE)) {
+  if (in_array('login', config_get('civicrm_member_roles.settings', 'civicrm_member_roles_sync_method') ?? [], TRUE)) {
     _civicrm_member_roles_sync($account->uid);
   }
 }
@@ -125,7 +125,7 @@ function civicrm_member_roles_cron() {
   if (!civicrm_initialize(TRUE)) {
     return;
   }
-  if (in_array('cron', config_get('civicrm_member_roles.settings', 'civicrm_member_roles_sync_method'), TRUE)) {
+  if (in_array('cron', config_get('civicrm_member_roles.settings', 'civicrm_member_roles_sync_method') ?? [], TRUE)) {
     _civicrm_member_roles_sync(NULL, NULL, 'cron');
   }
 }
@@ -673,7 +673,7 @@ function _civicrm_member_roles_get_data($type) {
 
 function civicrm_member_roles_civicrm_post($op, $objname, $objid, &$objref) {
   if ($objname == "Membership") {
-    if (in_array('update', config_get('civicrm_member_roles.settings', 'civicrm_member_roles_sync_method'), TRUE)) {
+    if (in_array('update', config_get('civicrm_member_roles.settings', 'civicrm_member_roles_sync_method') ?? [], TRUE)) {
       _civicrm_member_roles_sync(NULL, $objref->contact_id);
     }
   }


### PR DESCRIPTION
In PHP 8, `in_array()` uses strict type checking, so using `config_get()` as an array doesn't always work because `config_get()` can return `NULL`.

This fixes `civicrm_member_roles` to pass an empty array to `in_array()` when `config_get()` returns `NULL`.