### PR TITLE
dev/core#3991 Bump minimum PHP version to 7.3.0

### DIFF
--- a/civicrm.info
+++ b/civicrm.info
@@ -4,7 +4,7 @@ version = 1.x-4.7
 package = CiviCRM
 backdrop = 1.x
 project = civicrm
-php = 7.2
+php = 7.3
 type = module
 
 stylesheets[all][] = civicrm_backdrop.css

--- a/civicrm.module
+++ b/civicrm.module
@@ -43,7 +43,7 @@ define('CIVICRM_UF_HEAD', TRUE);
  * @see CRM_Upgrade_Incremental_General::MIN_INSTALL_PHP_VER
  * @see CiviBackdrop\PhpVersionTest::testConstantMatch()
  */
-define('CIVICRM_BACKDROP_PHP_MINIMUM', '7.2.0');
+define('CIVICRM_BACKDROP_PHP_MINIMUM', '7.3.0');
 
 /**
  * Adds CiviCRM CSS and JS resources into the header.


### PR DESCRIPTION
Note this will fail until https://github.com/civicrm/civicrm-core/pull/25147 is merged

@colemanw @totten @eileenmcnaughton 