### PR TITLE
PHP8 fix for civicrm-group-sync

### DIFF
--- a/modules/civicrm_group_roles/civicrm_group_roles.module
+++ b/modules/civicrm_group_roles/civicrm_group_roles.module
@@ -100,6 +100,7 @@ function civicrm_group_roles_add_groups_oncreate($account, $roles) {
 
   $config = config('civicrm_group_roles.settings');
   $result = $config->get('rules');
+  $group_ids = [];
   foreach ($result as $rule) {
     if (in_array($rule['role_name'], array_keys($roles))) {
       $group_ids[] = $rule['group_id'];


### PR DESCRIPTION
https://civicrm.stackexchange.com/q/47818/12 reports a PHP8 compatibility issue, this is a proposed fix (intializing a variable as an empty array).