### PR TITLE
Setup UI - Restore icons (FontAwesome 6 support)

### DIFF
--- a/civicrm.setup.inc
+++ b/civicrm.setup.inc
@@ -24,7 +24,7 @@ function civicrm_setup_page() {
       'ctrl' => url('civicrm'),
       'res' => $coreUrl . '/setup/res/',
       'jquery.js' => $coreUrl . '/bower_components/jquery/dist/jquery.min.js',
-      'font-awesome.css' => $coreUrl . '/bower_components/font-awesome/css/font-awesome.min.css',
+      'font-awesome.css' => $coreUrl . '/bower_components/font-awesome/css/all.min.css',
       // Not used? 'finished' => url('civicrm/dashboard', ['query' => ['reset' => 1],]),
     ));
     // return _civicrm_setup_runCtrl($ctrl);


### PR DESCRIPTION
Overview
------------

Fix missing icons when installing on Backdrop 5.77+.

Follow-up to 5.77.alpha's https://github.com/civicrm/civicrm-core/pull/30779 (cc @ufundo @herbdool)

Before
---------

No pencil icon. Instead, HTTP error.

> ![Screenshot from 2024-09-03 23-28-51](https://github.com/user-attachments/assets/d2b07744-543c-4a7e-af50-2122ad50afc6)

After
------

Icon works

> ![Screenshot from 2024-09-03 23-28-13](https://github.com/user-attachments/assets/c52b0a8b-eb03-4abe-aeae-d800db657853)

Comments
-------------

The fix is for 5.77-rc. We'll need to make sure to merge-forward to master.