### PR TITLE
Remove enforced glass effect on jQuery widgets

### DIFF
--- a/civicrm_backdrop.css
+++ b/civicrm_backdrop.css
@@ -2,13 +2,6 @@
   * Backdrop CSS which is needed on non-CiviCRM pages, too.
   */
 
-/* Override Backdrop's CSS for CRM-provided UI. */
-#crm-container .ui-state-default,
-#crm-container .ui-widget-content .ui-state-default,
-#crm-container .ui-widget-header .ui-state-default {
-  background: #e6e6e6 url(../bower_components/jquery-ui/themes/smoothness/images/ui-bg_glass_75_e6e6e6_1x400.png) 50% 50% repeat-x;
-}
-
 /* Display old icon */
 /* Support Backdrop < 1.28.0 without Icon API */
 #admin-bar #admin-bar-menu > li > .dropdown > li.civicrm-icon-original > a.civicrm {


### PR DESCRIPTION
@herbdool I'm proposing to remove this CSS.

I think it was a case that:

- Civi's jqui CSS applied glass effect
- Backdrop CSS removed it
- This CSS added it back in again

However Riverlea themes make the background a variable that the different stream-themes define, and the CSS in this repo breaks that.
