### PR TITLE
Copy deprecated user tokens function back to module

### DIFF
--- a/modules/civicrm_rules/civicrm_rules.mailing-eval.inc
+++ b/modules/civicrm_rules/civicrm_rules.mailing-eval.inc
@@ -33,7 +33,6 @@ function civicrm_rules_rules_action_mailing_send_email($to,
     if (empty($toEmails)) {
       return;
     }
-    require_once 'CRM/Utils/Token.php';
     $tokens['mailing'] = array(
       'mailing.editUrl',
       'mailing.scheduleUrl',
@@ -61,7 +60,7 @@ function civicrm_rules_rules_action_mailing_send_email($to,
       //only process user permission tokens if used in toEmail
       if (in_array(trim($toEmail, '{}'), $tokens['user'])) {
         //we require a TO email, but can only send one; so we strip the first off and send the rest as CCs
-        $userEmails = explode(',', CRM_Utils_Token::replaceUserTokens($params['toEmail'], $tokens));
+        $userEmails = explode(',', _civicrm_rules_replaceUserTokens($params['toEmail'], $tokens));
         $params['toEmail'] = $userEmails[0];
         array_shift($userEmails);
         $params['cc'] = implode(',', $userEmails);
@@ -78,4 +77,72 @@ function civicrm_rules_condition_mailing_approved($mailing, $settings) {
 
 function civicrm_rules_condition_mailing_rejected($mailing, $settings) {
   return $mailing->approval_status_id != 1;
+}
+
+/**
+ * Replace all user tokens in $str
+ *
+ * @param string $str
+ *   The string with tokens to be replaced.
+ *
+ * @param null $knownTokens
+ * @param bool $escapeSmarty
+ *
+ * @return string
+ *   The processed string
+ *
+ */
+function _civicrm_rules_replaceUserTokens($str, $knownTokens = NULL, $escapeSmarty = FALSE) {
+  $key = 'user';
+  if (!$knownTokens ||
+    !isset($knownTokens[$key])
+  ) {
+    return $str;
+  }
+
+  $str = preg_replace_callback(
+    _civicrm_rules_tokenRegex($key),
+    function ($matches) use ($escapeSmarty) {
+      return _civicrm_rules_getUserTokenReplacement($matches[1], $escapeSmarty);
+    },
+    $str
+  );
+  return $str;
+}
+
+/**
+ * @param $token
+ * @param bool $escapeSmarty
+ *
+ * @return string
+ */
+function _civicrm_rules_getUserTokenReplacement($token, $escapeSmarty = FALSE) {
+  $value = '';
+
+  [$objectName, $objectValue] = explode('-', $token, 2);
+
+  switch ($objectName) {
+    case 'permission':
+      $value = CRM_Core_Config::singleton()->userPermissionClass->permissionEmails($objectName);
+      break;
+
+    case 'role':
+      $value = CRM_Core_Config::singleton()->userRoleClass->roleEmails($objectValue);
+      break;
+  }
+
+  if ($escapeSmarty) {
+    $value = _civicrm_rules_tokenEscapeSmarty($value);
+  }
+
+  return $value;
+}
+
+function _civicrm_rules_tokenEscapeSmarty($string) {
+  // need to use negative look-behind, as both str_replace() and preg_replace() are sequential
+  return preg_replace(['/{/', '/(?<!{ldelim)}/'], ['{ldelim}', '{rdelim}'], $string);
+}
+
+function _civicrm_rules_tokenRegex(string $token_type) {
+  return '/(?<!\{|\\\\)\{' . $token_type . '\.([\w]+(:|\.)?\w*(\-[\w\s]+)?)\}(?!\})/';
 }


### PR DESCRIPTION
The civicrm_rules module that ships with backdrop is not the widely used based on CiviCRM Entity

This function has no other use in supported code so better to contain it within the extension